### PR TITLE
JPA 동적 스키마 적용 ( 쿼리문 수정 ) 

### DIFF
--- a/src/main/java/com/jpa/sharding/app/product/domain/Product.java
+++ b/src/main/java/com/jpa/sharding/app/product/domain/Product.java
@@ -1,5 +1,6 @@
 package com.jpa.sharding.app.product.domain;
 
+import com.jpa.sharding.config.constant.ConstantDB;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,9 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Table
+@Table(
+        catalog = ConstantDB.SHARD_DB_SCHEMA_NAME
+)
 @NoArgsConstructor
 @Entity
 public class Product {

--- a/src/main/java/com/jpa/sharding/config/HibernateCommonProperties.java
+++ b/src/main/java/com/jpa/sharding/config/HibernateCommonProperties.java
@@ -1,7 +1,9 @@
 package com.jpa.sharding.config;
 
+import com.jpa.sharding.config.hibernate.HibernateInterceptor;
 import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +20,13 @@ public class HibernateCommonProperties {
         properties.put(AvailableSettings.FORMAT_SQL, true);
         properties.put(AvailableSettings.PHYSICAL_NAMING_STRATEGY, CamelCaseToUnderscoresNamingStrategy.class.getName());
         properties.put(AvailableSettings.IMPLICIT_NAMING_STRATEGY, SpringImplicitNamingStrategy.class.getName());
+
+        // 각 DB 별로 새롭게 만들거면 각각 프로퍼티를 따로 지정해줘야함
+//        properties.put(AvailableSettings.INTERCEPTOR, HibernateInterceptor.class);
+
+
+        properties.put(AvailableSettings.STATEMENT_INSPECTOR, HibernateInterceptor.class);
+
         return properties;
     }
 }

--- a/src/main/java/com/jpa/sharding/config/constant/ConstantDB.java
+++ b/src/main/java/com/jpa/sharding/config/constant/ConstantDB.java
@@ -10,4 +10,6 @@ public class ConstantDB {
 
     public static final String SHARD_TRANSACTION_MANAGER_NAME = "shardTransactionManagerName";
 
+    public static final String SHARD_DB_SCHEMA_NAME =  "jpa_shard_#shard_number#";
+
 }

--- a/src/main/java/com/jpa/sharding/config/datasource/DataSourceConfig.java
+++ b/src/main/java/com/jpa/sharding/config/datasource/DataSourceConfig.java
@@ -29,21 +29,21 @@ public class DataSourceConfig {
 
         Map<Object, Object> dataSourceMap = new HashMap<>();
 
-        for (int i = 1; i <= dbProperties.getCount(); i++) {
-            HikariConfig hikariConfig = new HikariConfig();
-            hikariConfig.setDriverClassName(dbProperties.getDriverClassName());
-            hikariConfig.setUsername(dbProperties.getUserName());
-            hikariConfig.setPassword(dbProperties.getPassWord());
-            hikariConfig.setJdbcUrl(dbProperties.getJdbcUrl() + i);
-            hikariConfig.setMaximumPoolSize(3);
-            hikariConfig.setMinimumIdle(1);
-            dataSourceMap.put(MASTER + i, new HikariDataSource(hikariConfig));
-            dataSourceMap.put(SLAVE + i, new HikariDataSource(hikariConfig));
-        }
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDriverClassName(dbProperties.getDriverClassName());
+        hikariConfig.setUsername(dbProperties.getUserName());
+        hikariConfig.setPassword(dbProperties.getPassWord());
+        hikariConfig.setJdbcUrl(dbProperties.getJdbcUrl());
+        hikariConfig.setMaximumPoolSize(40);
+        hikariConfig.setMinimumIdle(10);
+        dataSourceMap.put(MASTER, new HikariDataSource(hikariConfig));
+        dataSourceMap.put(SLAVE, new HikariDataSource(hikariConfig));
 
         DBRoutingDataSource routingDataSource = new DBRoutingDataSource();
-        routingDataSource.setDefaultTargetDataSource(dataSourceMap.get(MASTER + 1)); // 변경 필요
+        routingDataSource.setDefaultTargetDataSource(dataSourceMap.get(MASTER)); // 변경 필요
         routingDataSource.setTargetDataSources(dataSourceMap);
+
+
         return routingDataSource;
     }
 

--- a/src/main/java/com/jpa/sharding/config/hibernate/HibernateInterceptor.java
+++ b/src/main/java/com/jpa/sharding/config/hibernate/HibernateInterceptor.java
@@ -1,0 +1,26 @@
+package com.jpa.sharding.config.hibernate;
+
+import com.jpa.sharding.config.routing.DBRoutingManager;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+
+/**
+ * extends EmptyInterceptor 를 이용하여 구현 할 수도 있습니다.
+ * 다만 해당 클래스에서 onPrepareStatement 는 상위 클래스인 Interceptor 에서 deprecated 되어있으므로
+ * StatementInspector 사용을 권장 하고 있습니다.
+ *
+ * 하이버 네이트 에서 쿼리문을 바꿔줄 인터셉터
+ * @author pursue503
+ */
+@Slf4j
+@Component
+public class HibernateInterceptor  implements StatementInspector {
+
+    @Override
+    public String inspect(String sql) {
+        String shardNumber = DBRoutingManager.getDataSourceName();
+        sql = sql.replaceAll("#shard_number#", shardNumber);
+        return sql;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 shard.driverClassName=com.mysql.cj.jdbc.Driver
 shard.username=root
 shard.password=jpa_db_sharding_mysql
-shard.jdbcUrl=jdbc:mysql://localhost:3306/jpa_shard_
+shard.jdbcUrl=jdbc:mysql://localhost:3306/
 shard.count=32


### PR DESCRIPTION
## 기존
논리 디비 기준으로 샤딩한거라 각 논리 디비 별로 1개 커넥션 풀이 생성되고 커넥션이 만들어짐   
커넥션이 너무 많아져 To Many Connection 발생

### 기존 방법의 문제점
1. 논리디비 기준으로 같은 디비에 논리디비 수만큼 샤딩되기 떄문에 커넥션이 머무 많아짐
2. JPA 에는 동적 스키마 설정이 안될거라고 생각 하였음

## 변경

###  EmptyInterceptor 사용 ( deprecated ) 
1. EmptyInterceptor 의 onPrepareStatement 를 오버라이딩 하여 sql 쿼리문을 변경 할 수 있음
2. 엔티티의 스키마를 설정하고 쿼리문을 replace 해줌

### StatementInspector 사용
1. StatementInspector 를 사용하여 sql 문만 오버라이딩 하여 여기서 replace 해줌


### 변경 후 문제점 해결
1. JPA 에서 동적 스키마 변경이 가능하여 하나의 물리 디비 수만큼 커넥션풀을 생성 
2. 논리 디비 수만큼 커넥션 풀 생성할 필요가 없어짐 ( 10 * 64 )


---
> 해당 기능은 물리 db, 논리 db, 테이블 샤딩 전부 사용이 가능합니다.
